### PR TITLE
fix: PR changes

### DIFF
--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -663,7 +663,7 @@ public class SpireAnniversary6Mod implements
     public static float time = 0f;
     @Override
     public void receivePostUpdate() {
-        time += Gdx.graphics.getDeltaTime();
+        time += Gdx.graphics.getRawDeltaTime();
     }
 
     public static class SavableCurrentRunActive implements CustomSavable<Boolean> {

--- a/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
+++ b/src/main/java/spireMapOverhaul/SpireAnniversary6Mod.java
@@ -63,6 +63,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
 
+import static spireMapOverhaul.zones.storm.StormZone.*;
+
 @SuppressWarnings({"unused"})
 @SpireInitializer
 public class SpireAnniversary6Mod implements
@@ -106,10 +108,7 @@ public class SpireAnniversary6Mod implements
     private static final String SKILL_L_ART = modID + "Resources/images/1024/skill.png";
     private static final String POWER_L_ART = modID + "Resources/images/1024/power.png";
 
-    public static final String THUNDER_KEY = makeID("Storm_Thunder");
-    private static final String THUNDER_MP3 = makePath("audio/storm/thunder.mp3");
-    public static final String RAIN_KEY = makeID("Storm_Rain");
-    private static final String RAIN_MP3 = makePath("audio/storm/rain.mp3");
+
 
     public static boolean initializedStrings = false;
 

--- a/src/main/java/spireMapOverhaul/patches/interfacePatches/TravelTrackingPatches.java
+++ b/src/main/java/spireMapOverhaul/patches/interfacePatches/TravelTrackingPatches.java
@@ -48,6 +48,10 @@ public class TravelTrackingPatches {
                 return;
             }
 
+            if (nextZone instanceof OnTravelZone) {
+                ((OnTravelZone) nextZone).onEnterRoom();
+            }
+
             //Next room has a zone, check if it's a new one.
             String lastZoneID = Field.lastZoneID();
             if (!nextZone.id.equals(lastZoneID)) {

--- a/src/main/java/spireMapOverhaul/zoneInterfaces/OnTravelZone.java
+++ b/src/main/java/spireMapOverhaul/zoneInterfaces/OnTravelZone.java
@@ -3,4 +3,5 @@ package spireMapOverhaul.zoneInterfaces;
 public interface OnTravelZone {
     default void onEnter() { }
     default void onExit() { }
+    default void onEnterRoom() { }
 }

--- a/src/main/java/spireMapOverhaul/zones/storm/StormUtil.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormUtil.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import spireMapOverhaul.zones.storm.cardmods.DampModifier;
+import spireMapOverhaul.zones.storm.cardmods.ElectricModifier;
 
 import java.util.stream.Collectors;
 
@@ -45,7 +46,7 @@ public class StormUtil {
     }
 
     public static boolean cardValidToMakeDamp(AbstractCard c) {
-        return !CardModifierManager.hasModifier(c, DampModifier.ID);
+        return !CardModifierManager.hasModifier(c, DampModifier.ID) && !CardModifierManager.hasModifier(c, ElectricModifier.ID);
     }
 
     public static int countValidCardsInHandToMakeDamp() {

--- a/src/main/java/spireMapOverhaul/zones/storm/StormUtil.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormUtil.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import spireMapOverhaul.zones.storm.cardmods.DampModifier;
 import spireMapOverhaul.zones.storm.cardmods.ElectricModifier;
@@ -23,6 +24,9 @@ public class StormUtil {
     public static long rainSoundId;
     public static boolean activePlayerLightning;
     public static float brightTime;
+    public static AbstractCreature conduitTarget;
+    public static float timeToStrike;
+    public static float timeSinceStrike;
 
     public static FrameBuffer createBuffer() {
         return createBuffer(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -59,8 +59,8 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
 
     @Override
     public void modifyRewardCards(ArrayList<AbstractCard> cards) {
-        if(AbstractDungeon.cardRandomRng.randomBoolean()) {
-            AbstractCard card = cards.get(AbstractDungeon.cardRandomRng.random(cards.size() - 1));
+        if(AbstractDungeon.getCurrRoom() instanceof  MonsterRoomElite || AbstractDungeon.cardRng.randomBoolean()) {
+            AbstractCard card = cards.get(AbstractDungeon.cardRng.random(cards.size() - 1));
             CardModifierManager.addModifier(card, new ElectricModifier());
         }
     }

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -8,6 +8,7 @@ import com.megacrit.cardcrawl.cards.blue.Storm;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.rooms.MonsterRoomElite;
 import spireMapOverhaul.SpireAnniversary6Mod;
 import spireMapOverhaul.abstracts.AbstractZone;
 import spireMapOverhaul.zoneInterfaces.CombatModifyingZone;
@@ -20,13 +21,18 @@ import spireMapOverhaul.zones.storm.powers.ConduitPower;
 
 import java.util.ArrayList;
 
-import static spireMapOverhaul.SpireAnniversary6Mod.RAIN_KEY;
+import static spireMapOverhaul.SpireAnniversary6Mod.*;
 import static spireMapOverhaul.util.Wiz.*;
 import static spireMapOverhaul.zones.storm.StormUtil.cardValidToMakeDamp;
 import static spireMapOverhaul.zones.storm.StormUtil.countValidCardsInHandToMakeDamp;
 
 public class StormZone extends AbstractZone implements CombatModifyingZone, RewardModifyingZone, OnTravelZone {
     public static final String ID = "Storm";
+
+    public static final String THUNDER_KEY = makeID("Storm_Thunder");
+    public static final String THUNDER_MP3 = makePath("audio/storm/thunder.mp3");
+    public static final String RAIN_KEY = makeID("Storm_Rain");
+    public static final String RAIN_MP3 = makePath("audio/storm/rain.mp3");
 
     public StormZone() {
         super(ID, Icons.MONSTER);

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -73,9 +73,9 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
                 public void update() {
                     int validCards = countValidCardsInHandToMakeDamp();
                     if(validCards > 0) {
-                        AbstractCard card = AbstractDungeon.player.hand.getRandomCard(AbstractDungeon.miscRng);
+                        AbstractCard card = AbstractDungeon.player.hand.getRandomCard(AbstractDungeon.cardRandomRng);
                         while (!cardValidToMakeDamp(card)) { //Get random cards until you get one you can make damp
-                            card = AbstractDungeon.player.hand.getRandomCard(AbstractDungeon.miscRng);
+                            card = AbstractDungeon.player.hand.getRandomCard(AbstractDungeon.cardRandomRng);
                         }
                         CardModifierManager.addModifier(card, new DampModifier());
                         card.flash();

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -78,7 +78,7 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
                             card = AbstractDungeon.player.hand.getRandomCard(AbstractDungeon.cardRandomRng);
                         }
                         CardModifierManager.addModifier(card, new DampModifier());
-                        card.flash();
+                        card.superFlash();
                     }
                     isDone = true;
                 }

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -23,8 +23,7 @@ import java.util.ArrayList;
 
 import static spireMapOverhaul.SpireAnniversary6Mod.*;
 import static spireMapOverhaul.util.Wiz.*;
-import static spireMapOverhaul.zones.storm.StormUtil.cardValidToMakeDamp;
-import static spireMapOverhaul.zones.storm.StormUtil.countValidCardsInHandToMakeDamp;
+import static spireMapOverhaul.zones.storm.StormUtil.*;
 
 public class StormZone extends AbstractZone implements CombatModifyingZone, RewardModifyingZone, OnTravelZone {
     public static final String ID = "Storm";
@@ -92,11 +91,11 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
         int totalActors = mons.size() + 1;
 
         if (AbstractDungeon.cardRandomRng.random(1, totalActors) == 1) {
-            AddLightningPatch.AbstractRoomFields.conduitTarget.set(AbstractDungeon.getCurrRoom(), AbstractDungeon.player);
+            conduitTarget = AbstractDungeon.player;
             applyToSelf(new ConduitPower(AbstractDungeon.player));
         } else {
             AbstractMonster m = AbstractDungeon.getMonsters().getRandomMonster(null, true, AbstractDungeon.cardRandomRng);
-            AddLightningPatch.AbstractRoomFields.conduitTarget.set(AbstractDungeon.getCurrRoom(), m);
+            conduitTarget = m;
             applyToEnemy(m, new ConduitPower(m));
         }
 

--- a/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/StormZone.java
@@ -50,11 +50,14 @@ public class StormZone extends AbstractZone implements CombatModifyingZone, Rewa
         return Color.DARK_GRAY.cpy();
     }
 
-    public void onEnter() {
-        StormUtil.rainSoundId = CardCrawlGame.sound.playAndLoop(RAIN_KEY, 0.5f);
+    public void onEnterRoom() {
+        if(StormUtil.rainSoundId == 0L) {
+            StormUtil.rainSoundId = CardCrawlGame.sound.playAndLoop(RAIN_KEY);
+        }
     }
     public void onExit() {
         CardCrawlGame.sound.stop(RAIN_KEY, StormUtil.rainSoundId);
+        StormUtil.rainSoundId = 0L;
     }
 
     @Override

--- a/src/main/java/spireMapOverhaul/zones/storm/actions/TogglePlayerElecticShaderAction.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/actions/TogglePlayerElecticShaderAction.java
@@ -21,6 +21,6 @@ public class TogglePlayerElecticShaderAction extends AbstractGameAction {
             StormUtil.activePlayerLightning = false;
             isDone = true;
         }
-        duration -= Gdx.graphics.getDeltaTime();
+        duration -= Gdx.graphics.getRawDeltaTime();
     }
 }

--- a/src/main/java/spireMapOverhaul/zones/storm/cardmods/ElectricModifier.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/cardmods/ElectricModifier.java
@@ -2,6 +2,7 @@ package spireMapOverhaul.zones.storm.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
 import basemod.helpers.CardModifierManager;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.actions.utility.SFXAction;
@@ -50,5 +51,12 @@ public class ElectricModifier extends AbstractCardModifier {
         atb(new VFXAction(new DispelPlayerElectricEffect(AbstractDungeon.player.hb.cX, AbstractDungeon.player.hb.cY)));
         atb(new SFXAction("ORB_PLASMA_CHANNEL", 0.1f));
         atb(new GainEnergyAction(1));
+        atb(new AbstractGameAction() {
+            @Override
+            public void update() {
+                CardModifierManager.removeModifiersById(card, ID, false);
+                isDone = true;
+            }
+        });
     }
 }

--- a/src/main/java/spireMapOverhaul/zones/storm/cardmods/ElectricModifier.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/cardmods/ElectricModifier.java
@@ -1,7 +1,9 @@
 package spireMapOverhaul.zones.storm.cardmods;
 
+import basemod.BaseMod;
 import basemod.abstracts.AbstractCardModifier;
 import basemod.helpers.CardModifierManager;
+import basemod.helpers.TooltipInfo;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
@@ -13,6 +15,9 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import spireMapOverhaul.zones.storm.actions.TogglePlayerElecticShaderAction;
 import spireMapOverhaul.zones.storm.vfx.DispelPlayerElectricEffect;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static spireMapOverhaul.SpireAnniversary6Mod.makeID;
 import static spireMapOverhaul.util.Wiz.atb;
@@ -41,8 +46,11 @@ public class ElectricModifier extends AbstractCardModifier {
         return CardCrawlGame.languagePack.getUIString(makeID("Electric")).TEXT[0] + cardName;
     }
 
-    public String modifyDescription(String rawDescription, AbstractCard card) {
-        return rawDescription + CardCrawlGame.languagePack.getUIString(makeID("Electric")).TEXT[1];
+    @Override
+    public List<TooltipInfo> additionalTooltips(AbstractCard card) {
+        ArrayList<TooltipInfo> tooltips = new ArrayList<>();
+        tooltips.add(new TooltipInfo(BaseMod.getKeywordTitle(makeID("electric")), BaseMod.getKeywordDescription(makeID("electric"))));
+        return tooltips;
     }
 
     @Override

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
@@ -36,7 +36,7 @@ public class AddLightningPatch {
         private static float timeScaleStart = 0.1F;
         private static float timeScaleEnd = 0.3F;
         @SpirePrefixPatch()
-        public static void Prefix() {
+        public static void ICanNameMyPatchClassesWhateverIWantGKLOL() {
             if(StormUtil.isInStormZone()) {
                 //Lightning Strikes
                 if (AbstractRoomFields.timeToStrike.get(AbstractDungeon.getCurrRoom()) < 0.0f) {

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
@@ -49,14 +49,14 @@ public class AddLightningPatch {
                     AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), MathUtils.random(3.5f, 10.0f));
                     AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), 0.0f);
                 }
-                AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeToStrike.get(AbstractDungeon.getCurrRoom()) - Gdx.graphics.getDeltaTime());
-                AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeSinceStrike.get(AbstractDungeon.getCurrRoom()) + Gdx.graphics.getDeltaTime());
+                AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeToStrike.get(AbstractDungeon.getCurrRoom()) - Gdx.graphics.getRawDeltaTime());
+                AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeSinceStrike.get(AbstractDungeon.getCurrRoom()) + Gdx.graphics.getRawDeltaTime());
 
 
                 //Conduit power vfx that happens during turn
                 AbstractCreature conduitTarget = AbstractRoomFields.conduitTarget.get(AbstractDungeon.getCurrRoom());
                 if(conduitTarget != null) {
-                    vfxTimer -= Gdx.graphics.getDeltaTime();
+                    vfxTimer -= Gdx.graphics.getRawDeltaTime();
                     if (vfxTimer < 0.0f) {
                         AbstractDungeon.topLevelEffectsQueue.add(new ImpactSparkEffect(conduitTarget.drawX +
                                 MathUtils.random(-20.0F, 20.0f) * Settings.scale, conduitTarget.drawY +

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
@@ -2,7 +2,6 @@ package spireMapOverhaul.zones.storm.patches;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.MathUtils;
-import com.evacipated.cardcrawl.modthespire.lib.SpireField;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
@@ -12,22 +11,15 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.vfx.combat.ImpactSparkEffect;
-import spireMapOverhaul.SpireAnniversary6Mod;
 import spireMapOverhaul.zones.storm.StormUtil;
 import spireMapOverhaul.zones.storm.vfx.AlwaysBehindLightningEffect;
 
 import static spireMapOverhaul.util.Wiz.atb;
+import static spireMapOverhaul.zones.storm.StormUtil.*;
 import static spireMapOverhaul.zones.storm.StormZone.THUNDER_KEY;
 
 
 public class AddLightningPatch {
-
-    @SpirePatch(clz = AbstractRoom.class, method = SpirePatch.CLASS)
-    public static class AbstractRoomFields {
-        public static SpireField<Float> timeToStrike = new SpireField<>(() -> 4.0f);
-        public static SpireField<Float> timeSinceStrike = new SpireField<>(() -> 1.0f);
-        public static SpireField<AbstractCreature> conduitTarget = new SpireField<>(() -> null);
-    }
 
     @SpirePatch(clz = AbstractRoom.class, method = "update")
     public static class GreaseLightning {
@@ -39,22 +31,21 @@ public class AddLightningPatch {
         public static void ICanNameMyPatchClassesWhateverIWantGKLOL() {
             if(StormUtil.isInStormZone()) {
                 //Lightning Strikes
-                if (AbstractRoomFields.timeToStrike.get(AbstractDungeon.getCurrRoom()) < 0.0f) {
+                if (timeToStrike < 0.0f) {
                     float rand_y = MathUtils.random(((float) Settings.HEIGHT / 2) - 50.0f * Settings.scale, ((float) Settings.HEIGHT / 2) - 350.0f * Settings.scale);
                     boolean renderBehind = rand_y > (float) Settings.HEIGHT / 2 - 250.0f;
                     atb(new VFXAction(new AlwaysBehindLightningEffect(MathUtils.random(Settings.WIDTH), rand_y, renderBehind)));
                     if(Settings.AMBIANCE_ON) {
                         atb(new SFXAction(THUNDER_KEY, 0.2f));
                     }
-                    AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), MathUtils.random(3.5f, 10.0f));
-                    AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), 0.0f);
+                    timeToStrike = MathUtils.random(3.5f, 10.0f);
+                    timeSinceStrike = 0.0f;
                 }
-                AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeToStrike.get(AbstractDungeon.getCurrRoom()) - Gdx.graphics.getRawDeltaTime());
-                AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), AbstractRoomFields.timeSinceStrike.get(AbstractDungeon.getCurrRoom()) + Gdx.graphics.getRawDeltaTime());
-
+                timeToStrike = timeToStrike - Gdx.graphics.getRawDeltaTime();
+                timeSinceStrike = timeSinceStrike + Gdx.graphics.getRawDeltaTime();
 
                 //Conduit power vfx that happens during turn
-                AbstractCreature conduitTarget = AbstractRoomFields.conduitTarget.get(AbstractDungeon.getCurrRoom());
+                AbstractCreature conduitTarget = StormUtil.conduitTarget;
                 if(conduitTarget != null) {
                     vfxTimer -= Gdx.graphics.getRawDeltaTime();
                     if (vfxTimer < 0.0f) {

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/AddLightningPatch.java
@@ -17,6 +17,7 @@ import spireMapOverhaul.zones.storm.StormUtil;
 import spireMapOverhaul.zones.storm.vfx.AlwaysBehindLightningEffect;
 
 import static spireMapOverhaul.util.Wiz.atb;
+import static spireMapOverhaul.zones.storm.StormZone.THUNDER_KEY;
 
 
 public class AddLightningPatch {
@@ -43,7 +44,7 @@ public class AddLightningPatch {
                     boolean renderBehind = rand_y > (float) Settings.HEIGHT / 2 - 250.0f;
                     atb(new VFXAction(new AlwaysBehindLightningEffect(MathUtils.random(Settings.WIDTH), rand_y, renderBehind)));
                     if(Settings.AMBIANCE_ON) {
-                        atb(new SFXAction(SpireAnniversary6Mod.THUNDER_KEY, 0.2f));
+                        atb(new SFXAction(THUNDER_KEY, 0.2f));
                     }
                     AbstractRoomFields.timeToStrike.set(AbstractDungeon.getCurrRoom(), MathUtils.random(3.5f, 10.0f));
                     AbstractRoomFields.timeSinceStrike.set(AbstractDungeon.getCurrRoom(), 0.0f);

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/ApplyShadersToActorsPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/ApplyShadersToActorsPatch.java
@@ -21,8 +21,7 @@ import spireMapOverhaul.zones.storm.StormUtil;
 import java.util.ArrayList;
 
 import static spireMapOverhaul.SpireAnniversary6Mod.time;
-import static spireMapOverhaul.zones.storm.StormUtil.initDarkShader;
-import static spireMapOverhaul.zones.storm.StormUtil.initElectricShader;
+import static spireMapOverhaul.zones.storm.StormUtil.*;
 
 public class ApplyShadersToActorsPatch {
     private static ShaderProgram darkShader = null;
@@ -82,7 +81,7 @@ public class ApplyShadersToActorsPatch {
                     darkShader = initDarkShader(darkShader);
                     sb.begin();
                     sb.setShader(darkShader);
-                    darkShader.setUniformf("u_time", AddLightningPatch.AbstractRoomFields.timeSinceStrike.get(AbstractDungeon.getCurrRoom()));
+                    darkShader.setUniformf("u_time", timeSinceStrike);
                 }
                 sb.draw(playerTexture, -Settings.VERT_LETTERBOX_AMT, -Settings.HORIZ_LETTERBOX_AMT);
                 sb.setShader(null);

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/RainPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/RainPatch.java
@@ -136,6 +136,18 @@ public class RainPatch {
         public static void Postfix() {
             if (StormUtil.isInStormZone()) {
                 CardCrawlGame.sound.adjustVolume(RAIN_KEY, StormUtil.rainSoundId, 0.0f);
+                StormUtil.rainSoundId = 0L;
+            }
+        }
+    }
+
+    @SpirePatch(clz = AbstractScene.class, method = "muteAmbienceVolume")
+    public static class MuteAmbiencePatch {
+
+        @SpirePostfixPatch
+        public static void Postfix() {
+            if (StormUtil.isInStormZone()) {
+                CardCrawlGame.sound.adjustVolume(RAIN_KEY, StormUtil.rainSoundId, 0.0f);
             }
         }
     }

--- a/src/main/java/spireMapOverhaul/zones/storm/patches/RainPatch.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/patches/RainPatch.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 
 import static spireMapOverhaul.SpireAnniversary6Mod.*;
+import static spireMapOverhaul.zones.storm.StormZone.RAIN_KEY;
 
 public class RainPatch {
     @SpirePatch(clz = AbstractScene.class, method = SpirePatch.CLASS)

--- a/src/main/java/spireMapOverhaul/zones/storm/vfx/AlwaysBehindLightningEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/vfx/AlwaysBehindLightningEffect.java
@@ -39,7 +39,7 @@ public class AlwaysBehindLightningEffect extends AbstractGameEffect {
                         MathUtils.random(-20.0F, 20.0F) * Settings.scale + 150.0F * Settings.scale, y +
                         MathUtils.random(-20.0F, 20.0F) * Settings.scale));
         }
-        duration -= Gdx.graphics.getDeltaTime();
+        duration -= Gdx.graphics.getRawDeltaTime();
         if (duration < 0.0F)
             isDone = true;
         color.a = Interpolation.bounceIn.apply(duration * 2.0F);

--- a/src/main/java/spireMapOverhaul/zones/storm/vfx/DispelPlayerElectricEffect.java
+++ b/src/main/java/spireMapOverhaul/zones/storm/vfx/DispelPlayerElectricEffect.java
@@ -20,7 +20,7 @@ public class DispelPlayerElectricEffect extends AbstractGameEffect {
     }
 
     public void update() {
-        duration -= Gdx.graphics.getDeltaTime();
+        duration -= Gdx.graphics.getRawDeltaTime();
         if (duration < 0.0F) {
             AbstractDungeon.effectsQueue.add(new EmptyStanceParticleEffect(x, y));
             AbstractDungeon.effectsQueue.add(new EmptyStanceParticleEffect(x, y));

--- a/src/main/resources/anniv6Resources/localization/eng/Storm/Keywordstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/Storm/Keywordstrings.json
@@ -5,5 +5,12 @@
       "damp"
     ],
     "DESCRIPTION": "Damp cards #yRetain and #yExhaust."
+  },
+  {
+    "PROPER_NAME": "Electric",
+    "NAMES": [
+      "electric"
+    ],
+    "DESCRIPTION": "When played, gain [E] [REMOVE_SPACE] and remove #yElectric."
   }
 ]

--- a/src/main/resources/anniv6Resources/localization/eng/Storm/Powerstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/Storm/Powerstrings.json
@@ -1,6 +1,6 @@
 {
   "${ModID}:ConduitPower": {
     "NAME": "Conduit",
-    "DESCRIPTIONS": ["Target will receive #b", " blockable damage at the end of the turn."]
+    "DESCRIPTIONS": ["Target will receive #b", " blockable damage at the end of the enemy turn."]
   }
 }

--- a/src/main/resources/anniv6Resources/localization/eng/Storm/UIstrings.json
+++ b/src/main/resources/anniv6Resources/localization/eng/Storm/UIstrings.json
@@ -2,7 +2,7 @@
   "${ModID}:Storm": {
     "TEXT": [
       "Storm",
-      "A thunderstorm is forecasted in this area of the Spire. Lightning will strike either the player or a monster, and you may be rewarded with special charged cards. Make sure to keep your hand out of the rain..."
+      "A thunderstorm is forecasted in this area of the Spire. Lightning will strike either the player or a monster, and you may be rewarded with special electric cards. Make sure to keep your hand out of the rain..."
     ]
   },
   "${ModID}:Damp": {
@@ -12,8 +12,7 @@
   },
   "${ModID}:Electric": {
     "TEXT": [
-      "Electric ",
-      " NL Gain [E]."
+      "Electric "
     ]
   }
 }


### PR DESCRIPTION
* Moved constants out of main file
* Using correct rng
* Electric mod changes:
    - Uses a tooltip box instead of changing text
    - Removes itself on use
    - 100% chance to appear on Elite combats
 * Damp cards flash brighter at the start of turns
 * Using rawDeltaTime everywhere
 * Fixed a bug where a card wasn't made damp if the selected random card was already electric
 * Fixed a bug where the rain sfx wouldn't load after exiting the game and starting again
 * Fixed a bug where rain sfx played even when the game was in the background while the setting to mute sounds in BG was on
 * 😎 
 * Removed using SpireFields where they weren't needed

* Added a hook for entering _any_ room in a zone 